### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.2.0 - 2020-02-05
+
 ### Changed
 - **Breaking Ether and Erc20 HTLCs:** A transaction to the HTLCs (Ether or Erc20) now `reverts` with an error message if someone tries to (1) refund too early or (2) redeem with a wrong secret. Additionally, the log messages have changed. For more details, checkout this PR: https://github.com/comit-network/blockchain-contracts/pull/37 .
 - **Breaking API Change**: The Ethereum HTLCs now accept byte arrays for both amounts and addresses instead of web3 crate types.
@@ -16,5 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add implementation of COMIT RFC-003 for Ether.
 - Add implementation of COMIT RFC-003 for ERC-20.
 
-[Unreleased]: https://github.com/coblox/blockchain-contracts/compare/0.1.0...HEAD
+[Unreleased]: https://github.com/coblox/blockchain-contracts/compare/0.2.0...HEAD
+[0.2.0]: https://github.com/coblox/blockchain-contracts/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/coblox/blockchain-contracts/compare/ab341e430ca514576ac9ca553a35ba339f293cc3...0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockchain_contracts"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["CoBloX developers <team@coblox.tech>"]
 edition = "2018"
 description = "Blockchain contracts used by COMIT-network daemons to execute cryptographic protocols."


### PR DESCRIPTION
### Changed
- **Breaking Ether and Erc20 HTLCs:** A transaction to the HTLCs (Ether or Erc20) now `reverts` with an error message if someone tries to (1) refund too early or (2) redeem with a wrong secret. Additionally, the log messages have changed. For more details, checkout this PR: https://github.com/comit-network/blockchain-contracts/pull/37 .
- **Breaking API Change**: The Ethereum HTLCs now accept byte arrays for both amounts and addresses instead of web3 crate types.

Step 1/2 for #40