### PR TITLE
Increase gas limit

### DIFF
--- a/src/ethereum/rfc003/erc20_htlc.rs
+++ b/src/ethereum/rfc003/erc20_htlc.rs
@@ -53,7 +53,7 @@ impl Erc20Htlc {
     pub fn refund_tx_gas_limit() -> u64 {
         // 20_705 consumed in local test for successful refunding
         // 21_058 to 21_673 consumed in local test for failed refunding
-        50_000
+        100_000
     }
 
     /// Constructs the payload to transfer `Erc20` tokens to a `to_address`


### PR DESCRIPTION
comit-rs e2e tests use more gas.

Anyone that can explain why this is needed is welcome to. It's the only way to get the e2e tests working.